### PR TITLE
Managed unit_list.json

### DIFF
--- a/app/assets/js/pa.js
+++ b/app/assets/js/pa.js
@@ -80,26 +80,31 @@ function createStreamObject(papath) {
     
     var binpath;
     var stockmodspath;
+    var mediapath;
     if (platform === 'win32') {
         binpath = path.join(papath, 'bin_x64/PA.exe');
-        stockmodspath = path.join(papath, '/media/stockmods');
+        mediapath = path.join(papath, '/media');
+        stockmodspath = path.join(mediapath, '/stockmods');
     }
     else if (platform === 'linux') {
         binpath = path.join(papath, 'PA');
-        stockmodspath = path.join(papath, '/media/stockmods');
+        mediapath = path.join(papath, '/media');
+        stockmodspath = path.join(mediapath, '/stockmods');
     }
     else if (platform === 'darwin') {
         binpath = path.join(papath, '/PA.app/Contents/MacOS/PA');
-        stockmodspath = path.join(papath, '/PA.app/Contents/Resources/stockmods/');
-        if(!fs.existsSync(stockmodspath)) {
-            stockmodspath = path.join(papath, '/PA.app/Contents/Resources/media/stockmods/');
+        mediapath = path.join(papath, '/PA.app/Contents/Resources/media/');
+        if(!fs.existsSync(mediapath)) {
+            mediapath = path.join(papath, '/PA.app/Contents/Resources/');
         }
+        stockmodspath = path.join(mediapath, '/stockmods/');
     }
     
     return {
         stream: stream
         ,build: version
         ,bin: binpath
+        ,media: mediapath
         ,stockmods: stockmodspath
     }
 }

--- a/app/assets/js/pamm-api.js
+++ b/app/assets/js/pamm-api.js
@@ -864,13 +864,17 @@ var _updateUnitList = function(context, enabledmods) {
     // mods/pamm/unit_list.json
     jsAddLogMessage("Processing " + context + " unit_list", 4);
 
-    var addedunits = [];
+    var add_units = [];
+    var remove_units = [];
     var unitmods = 0
     _.each(enabledmods, function(mod) {
         if ( mod.unit_list ) {
             unitmods = unitmods + 1
-            if ( mod.unit_list.units ) {
-                addedunits = addedunits.concat(mod.unit_list.units);
+            if ( mod.unit_list.add_units ) {
+                add_units = add_units.concat(mod.unit_list.add_units);
+            }
+            if ( mod.unit_list.remove_units ) {
+                remove_units = remove_units.concat(mod.unit_list.remove_units);
             }
         }
     });
@@ -902,7 +906,8 @@ var _updateUnitList = function(context, enabledmods) {
     {
         var unitlistpath = path.join(pa.streams[stream].media, "/pa_ex1/units/unit_list.json");
         var list = JSON.parse(fs.readFileSync(unitlistpath, {encoding: 'utf8'}));
-        list.units = list.units.concat(addedunits);
+        list.units = _.difference(list.units, remove_units);
+        list.units = _.union(list.units, add_units);
         var unit_list = JSON.stringify(list);
 
         jsAddLogMessage("Writing " + context + " unit_list.json", 4);

--- a/app/assets/js/pamm-api.js
+++ b/app/assets/js/pamm-api.js
@@ -722,7 +722,37 @@ var _updateFiles = function(context) {
         )
         ,function(mod) { return mod.priority }
     );
-    
+
+    var scenesRequired = _updateUiModList(context, enabledmods);
+
+    if ( scenesRequired )
+    {
+        jsAddLogMessage( 'Enabling PA ' + context + ' Mod Manager', 4);
+    }
+    else
+    {
+        jsAddLogMessage( 'Disabling PA ' + context + ' Mod Manager as not needed', 4);
+
+        var pamm_mod;
+        switch ( context )
+        {
+            case 'server':
+                pamm_mod = PAMM_SERVER_MOD_IDENTIFIER;
+                break;
+            case 'client':
+                pamm_mod = PAMM_MOD_IDENTIFIER;
+                break;
+            default:
+                jsAddLogMessage("Unknown context " + context, 4);
+        }
+
+        enabledmods = _.filter( enabledmods, function(mod) {return mod.identifier != pamm_mod});
+    }
+
+    _updateModsJson(context, enabledmods)
+}
+
+var _updateUiModList = function(context, enabledmods) {
     // mods/pamm/uimodlist
     jsAddLogMessage("Processing " + context + " scenes", 4);
     
@@ -762,8 +792,6 @@ var _updateFiles = function(context) {
     
     var pamm_path, uimodlist;
  
-    var mount_order = _.pluck( enabledmods,'identifier'); // may be modified for server mods
-    
     switch ( context )
     {
         
@@ -774,22 +802,6 @@ var _updateFiles = function(context) {
             // server version of ui_mod_list.js loads local client copy of ui_mod_list_for_server.js then merges server scenes into client scenes
     
             uimodlist = "var global_server_mod_list = " + JSON.stringify(globalmodlist, null, 4) + ";\n\nvar scene_server_mod_list = " + JSON.stringify(scenemodlist, null, 4) + ";\n\ntry { \n\nloadScript('coui://ui/mods/ui_mod_list_for_server.js');\n\ntry { global_mod_list = _.union( global_mod_list, global_server_mod_list ) } catch (e) { console.log(e); } ;\n\ntry { _.forOwn( scene_server_mod_list, function( value, key ) { if ( scene_mod_list[ key ] ) { scene_mod_list[ key ] = _.union( scene_mod_list[ key ], value ) } else { scene_mod_list[ key ] = value } } ); } catch (e) { console.log(e); } \n\n\} catch (e) {\n\nconsole.log(e);\n\nvar global_mod_list = global_server_mod_list;\n\nvar scene_mod_list = scene_server_mod_list;\n\n}\n\n";
-    
-            // for server mods we only enable the PA Server Mod Manager if there are other server mods enabled that use scenes
-    
-            var sceneCount = globalmodlist.length + _.flatten( _.values( scenemodlist ) ).length;
-            
-            jsAddLogMessage( 'Found ' + sceneCount + ' server mod scenes', 4);
-            
-            if ( sceneCount == 0 )
-            {
-                jsAddLogMessage( 'Disabling PA Server Mod Manager as not needed', 4);
-                mount_order = _.without( mount_order, PAMM_SERVER_MOD_IDENTIFIER );
-            }
-            else
-            {
-                jsAddLogMessage( 'Enabling PA Server Mod Manager', 4);                
-            }
     
             break;
         
@@ -839,11 +851,19 @@ var _updateFiles = function(context) {
             ,{ encoding: 'utf8' }
         );
     }
-    
+
+    var sceneCount = globalmodlist.length + _.flatten( _.values( scenemodlist ) ).length;
+
+    jsAddLogMessage( 'Found ' + sceneCount + ' ' + context + ' mod scenes', 4);
+
+    return sceneCount > 0;
+}
+
+var _updateModsJson = function(context, enabledmods) {
     // mods/mods.json
     
-    jsAddLogMessage("Writing " + context + " mods.json", 4);
-
+    var mount_order = _.pluck( enabledmods,'identifier');
+    jsAddLogMessage("Writing " + context + " mods.json with " + mount_order.length + " enabled mods", 4);
     var mods = { mount_order:mount_order };
     
     fs.writeFileSync(

--- a/app/assets/js/pamm-api.js
+++ b/app/assets/js/pamm-api.js
@@ -894,11 +894,12 @@ var _updateUnitList = function(context, enabledmods) {
     var unitmods = 0
     _.each(enabledmods, function(mod) {
         if ( mod.unit_list ) {
-            unitmods = unitmods + 1
             if ( mod.unit_list.add_units ) {
+                unitmods = unitmods + 1
                 add_units = add_units.concat(mod.unit_list.add_units);
             }
             if ( mod.unit_list.remove_units ) {
+                unitmods = unitmods + 1
                 remove_units = remove_units.concat(mod.unit_list.remove_units);
             }
         }


### PR DESCRIPTION
As described https://forums.uberent.com/threads/proposal-pamm-managed-unit_list-json.70960/

Recognizes extensions to modinfo.json, as well as inferring changes from unit_list.json in existing server mods. Changes applied using remove-then-add as described in forum topic.

As a result of refactoring, the pamm client mod may also be disabled if it is not required.